### PR TITLE
EHU-ATJS-20272 - Income Type field

### DIFF
--- a/cypress/e2e/petitionForm.cy.js
+++ b/cypress/e2e/petitionForm.cy.js
@@ -1,0 +1,18 @@
+import petitionForm from '../support/pages/petitionForm.page';
+
+describe('Income Type field in Petition for Space Travel form', () => {
+  beforeEach(() => {
+    petitionForm.visit();
+  });
+
+  it('Allows selecting an Income Type and shows it in output', () => {
+    petitionForm.selectIncomeType('Salary');
+    petitionForm.submit();
+    petitionForm.getIncomeTypeInOutput().should('contain.text', 'Salary');
+  });
+
+  it('Allows submitting the form without selecting Income Type (optional field)', () => {
+    petitionForm.submit();
+    petitionForm.getConfirmation().should('be.visible');
+  });
+});

--- a/cypress/support/pages/petitionForm.page.js
+++ b/cypress/support/pages/petitionForm.page.js
@@ -1,0 +1,24 @@
+class PetitionFormPage {
+    visit() {
+      cy.visit('/petition-for-space-travel'); 
+    }
+  
+    selectIncomeType(option) {
+      cy.get('select[placeholder="Select your income type"]').select(option);
+    }
+  
+    submit() {
+      cy.contains('Submit').click();
+    }
+  
+    getIncomeTypeInOutput() {
+      return cy.contains('Income Type').next(); 
+    }
+  
+    getIncomeTypeValidationError() {
+      return cy.contains('Please select an income type.');
+    }
+  }
+  
+  export default new PetitionFormPage();
+  

--- a/docs/petition_form_bdd.feature
+++ b/docs/petition_form_bdd.feature
@@ -1,0 +1,27 @@
+Feature: Submit Petition for Space Travel
+
+  Scenario: Successfully submit a valid petition
+    Given I open the Petition for Space Travel form
+    When I fill in all mandatory fields with valid data
+    And I select options from dropdowns
+    And I enter valid contact and address information
+    And I click the Submit button
+    Then I should see a confirmation message
+
+  Scenario: Validation errors on missing mandatory fields
+    Given I open the Petition for Space Travel form
+    When I leave required fields empty
+    And I click the Submit button
+    Then I should see validation messages for each empty mandatory field
+
+  Scenario: Validation error on invalid email format
+    Given I open the Petition for Space Travel form
+    When I enter an invalid email address
+    And I click the Submit button
+    Then I should see an error message about invalid email format
+
+  Scenario: Mismatched email confirmation
+    Given I open the Petition for Space Travel form
+    When I enter different email addresses in Email and Confirm Email
+    And I click the Submit button
+    Then I should see a message saying emails must match

--- a/docs/petition_form_bdd.feature
+++ b/docs/petition_form_bdd.feature
@@ -1,27 +1,17 @@
-Feature: Submit Petition for Space Travel
+Feature: Add "Income Type" field to Petition for Space Travel Form
 
-  Scenario: Successfully submit a valid petition
-    Given I open the Petition for Space Travel form
-    When I fill in all mandatory fields with valid data
-    And I select options from dropdowns
-    And I enter valid contact and address information
-    And I click the Submit button
-    Then I should see a confirmation message
+  As a user,
+  I want to select the type of income I receive
+  So that authorities can assess my financial situation accurately.
 
-  Scenario: Validation errors on missing mandatory fields
-    Given I open the Petition for Space Travel form
-    When I leave required fields empty
-    And I click the Submit button
-    Then I should see validation messages for each empty mandatory field
+  Scenario: Successfully submit form with selected Income Type
+    Given I am on the Petition for Space Travel form
+    When I select "Salary" from the Income Type dropdown
+    And I submit the form
+    Then the output table should display "Salary" as Income Type
 
-  Scenario: Validation error on invalid email format
-    Given I open the Petition for Space Travel form
-    When I enter an invalid email address
-    And I click the Submit button
-    Then I should see an error message about invalid email format
-
-  Scenario: Mismatched email confirmation
-    Given I open the Petition for Space Travel form
-    When I enter different email addresses in Email and Confirm Email
-    And I click the Submit button
-    Then I should see a message saying emails must match
+  Scenario: Successfully submit form without selecting Income Type
+    Given I am on the Petition for Space Travel form
+    When I do not select any option for Income Type
+    And I submit the form
+    Then the form should be submitted without validation errors

--- a/docs/petition_form_test_checklist.md
+++ b/docs/petition_form_test_checklist.md
@@ -1,0 +1,46 @@
+# Test Checklist 
+
+## Feature: Add "Income Type" Field to Petition for Space Travel Form
+
+---
+
+### Positive Test Case
+
+**Title**: Submit form with valid Income Type selected  
+**Preconditions**: User is on the Petition for Space Travel form  
+**Steps**:
+1. Scroll to Employment Information section
+2. Select "Salary" from the "Income Type" dropdown
+3. Click Submit
+
+**Expected Result**:  
+- Submission is successful  
+- Selected "Income Type" appears in the output table
+
+---
+
+### Optional Field Test
+
+**Title**: Submit form without selecting Income Type  
+**Steps**:
+1. Do not select any value in "Income Type"
+2. Fill other required fields
+3. Click Submit
+
+**Expected Result**:  
+- Form is submitted without errors  
+- "Income Type" may be blank in the output, and no validation message is shown
+
+---
+
+### Edge Case (optional)
+
+**Title**: Try submitting with invalid/empty value in dropdown  
+**Steps**:
+1. Manually clear the value in "Income Type" (if possible)
+2. Click Submit
+
+**Expected Result**:  
+- (If validation is enforced) Message "Please select an income type." appears  
+- Otherwise: Form still submits
+


### PR DESCRIPTION
Add "Income Type" Field to the Petition for Space Travel Form

Implemented UI automation test for the new optional field "Income Type".  
This dropdown allows users to select their income type (Salary, Hourly wage, Commission, Mixed).

---

### Included in this MR:

- `petitionForm.cy.js`: Cypress test with two scenarios
- `petitionForm.page.js`: Page Object for the Income Type field
- `petition_form_test_checklist.md`: Manual test checklist
- `petition_form_bdd.feature`: Gherkin BDD scenario

---

### Story Points: 5  

Standard dropdown field, with positive & optional tests, BDD + POM logic.

---

